### PR TITLE
fix : 새로고침시 로그인 상태 풀리는 문제 해결

### DIFF
--- a/client/components/common/Header.tsx
+++ b/client/components/common/Header.tsx
@@ -10,11 +10,23 @@ import { Logo } from '../yeonwoo/Logo';
 import { Nav } from '../yeonwoo/Nav';
 import { SearchBar } from '../yeonwoo/SearchBar';
 import { BtnDropdown } from '../yeonwoo/BtnDropdown';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState } from 'recoil';
 import { isLoginAtom } from '../../atomsYW';
+import { useEffect } from 'react';
 
 export const Header = () => {
-  const isLogin = useRecoilValue(isLoginAtom);
+  const [isLogin, setIsLogin] = useRecoilState(isLoginAtom);
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      if (localStorage.getItem('refreshToken')) {
+        setIsLogin(true);
+      } else {
+        setIsLogin(false);
+      }
+    } else {
+      setIsLogin(false);
+    }
+  }, []);
   return (
     <header className="flex items-center justify-between max-w-[1280px] mx-auto">
       <div className="flex items-center w-6/12">


### PR DESCRIPTION
- 로컬스토리지와 isLogin 전역상태 Header 파일에서 연결
  - 브랜치 나눠서 테스트 작업할 때는 뭔가 바로 안되었는데 브랜치 나누니까 한 번에 되버리네요? 에엥? ㅋㅋㅋㅋㅋ