### PR TITLE
fix : 유저의 아바타가 없을 때 헤더 아바타 이미지 적용 오류 해결

### DIFF
--- a/client/atomsYW.ts
+++ b/client/atomsYW.ts
@@ -83,3 +83,8 @@ export const userDashboardAtom = atom<userDashboard>({
     ],
   },
 });
+
+export const avatarPathAtom = atom({
+  key: 'avatarPath',
+  default: '/favicon.ico',
+});

--- a/client/components/yeonwoo/BtnUser.tsx
+++ b/client/components/yeonwoo/BtnUser.tsx
@@ -8,21 +8,34 @@ import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useRecoilState } from 'recoil';
+import { avatarPathAtom } from '../../atomsYW';
 
 export const BtnUser = () => {
+  const [avatarPath, setAvatarPath] = useRecoilState(avatarPathAtom);
+  const [isValid, setIsValid] = useState(true);
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const data = localStorage.getItem('avatarPath');
+      if (data !== null) setAvatarPath(data !== 'null' ? data : '/favicon.ico');
+      else setAvatarPath('/favicon.ico');
+    }
+  }, []);
   return (
     <Link href={`/dashboard/${localStorage.getItem('userId')}`}>
       <button className="flex items-center">
         <div className="w-[25px] h-[25px] rounded-full overflow-hidden">
-          <Image
-            src={
-              localStorage.getItem('avatarPath')
-                ? `${localStorage.getItem('avatarPath')}`
-                : '/favicon.ico'
-            }
-            width="25px"
-            height="25px"
-          />
+          {isValid ? (
+            <Image
+              src={avatarPath}
+              width="25px"
+              height="25px"
+              onError={() => setIsValid(false)}
+            />
+          ) : (
+            <Image src="/favicon.ico" width="25px" height="25px" />
+          )}
         </div>
         <span className="ml-2">{localStorage.getItem('nickname')}</span>
         <FontAwesomeIcon icon={faChevronRight} />


### PR DESCRIPTION
- localstorage 에서 키값이 있는 경우 value 가 null 로 적혀 있더라도 getItem 하면 해당 값이 null 이 아니라 'null' 로 들어와서 발생되는 문제였습니다
- 추후 아바타 변경시 바로 적용해야할 것 같아서 전역 상태로도 생성했습니다