### PR TITLE
배포 : 글 작성 버튼, 헤더 아바타 에러 해결, 메인 페이지/대시보드 항목 클릭시 해당 페이지 연결

### DIFF
--- a/client/atomsYW.ts
+++ b/client/atomsYW.ts
@@ -83,3 +83,8 @@ export const userDashboardAtom = atom<userDashboard>({
     ],
   },
 });
+
+export const avatarPathAtom = atom({
+  key: 'avatarPath',
+  default: '/favicon.ico',
+});

--- a/client/components/common/Editor.tsx
+++ b/client/components/common/Editor.tsx
@@ -182,20 +182,23 @@ export const Editor = () => {
         {...register('title')}
         onChange={handleTitleChange}
         type="text"
-        className="w-full border-2 px-2 py-1 justify-center leading-loose"
+        className="w-[97%] border-2 px-2 py-1 leading-loose mx-auto flex justify-center overflow-x-hidden"
         placeholder="제목을 입력해주세요!"
       />
       <label htmlFor="본문" className="font-bold ml-2 flex py-2 px-2">
         본문
       </label>
       <QuillEditor
-        className="h-96 mt-2 px-2"
+        className="h-96 w-[97%] mx-auto py-1"
         value={editorContent}
         modules={modules}
         onChange={editorChange}
         bounds="#editor"
         forwardRef={quillRef}
       />
+      <label htmlFor="태그" className="font-bold ml-2 flex py-2 mt-10 px-2">
+        태그
+      </label>
       <Select
         multiple
         options={options}

--- a/client/components/haseung/LoginForm.tsx
+++ b/client/components/haseung/LoginForm.tsx
@@ -63,7 +63,7 @@ export const LoginForm = () => {
         {...register('email', { required: true })}
         className="rounded-full w-96 h-10 placeholder:text-base placeholder:pl-3 placeholder:pb-2"
         type="text"
-        placeholder="hyejj19@naver.com"
+        placeholder="이메일을 입력해주세요."
       />
       <label>비밀번호</label>
       <input

--- a/client/components/haseung/QuestionList.tsx
+++ b/client/components/haseung/QuestionList.tsx
@@ -5,6 +5,7 @@
  * 개요: 질문 리스트를 표시합니다.
  */
 
+import Link from 'next/link';
 import { CreatedDate } from '../hyejung/CreatedDate';
 import { QuestionTitle } from '../hyejung/QuestionTitle';
 import { TagList } from '../hyejung/TagList';
@@ -13,6 +14,11 @@ import { UserNickname } from '../hyejung/UserNickname';
 export const QuestionList = () => {
   return (
     <section className="flex flex-col w-full mt-10">
+      <Link href="/ask">
+        <button className="bg-main-yellow hover:bg-main-orange w-20 mb-5 rounded-full p-2 ml-80">
+          질문하기
+        </button>
+      </Link>
       {[...Array(9)].map((_, i) => (
         <article key={i}>
           <QuestionTitle title="리액트 쿼리 질문드립니다." />

--- a/client/components/haseung/Select.tsx
+++ b/client/components/haseung/Select.tsx
@@ -56,7 +56,7 @@ export const Select = ({ multiple, tags, onChange, options }: SelectProps) => {
       onBlur={() => setIsOpen(false)}
       onClick={() => setIsOpen((prev) => !prev)}
       tabIndex={0}
-      className="relative w-80 top-20 min-h-[1.5em] flex justify-start ml-10 border-[0.05em] border-solid border-slate-800 gap-1 outline-none cursor-pointer hover:border-main-orange"
+      className="relative w-80 top-5 min-h-[1.5em] flex justify-start ml-10 border-[0.05em] border-solid border-slate-800 gap-1 outline-none cursor-pointer hover:border-main-orange"
     >
       <span className="flex-grow flex gap-2 flex-wrap">
         {multiple

--- a/client/components/yeonwoo/BtnUser.tsx
+++ b/client/components/yeonwoo/BtnUser.tsx
@@ -8,21 +8,34 @@ import { faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useRecoilState } from 'recoil';
+import { avatarPathAtom } from '../../atomsYW';
 
 export const BtnUser = () => {
+  const [avatarPath, setAvatarPath] = useRecoilState(avatarPathAtom);
+  const [isValid, setIsValid] = useState(true);
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const data = localStorage.getItem('avatarPath');
+      if (data !== null) setAvatarPath(data !== 'null' ? data : '/favicon.ico');
+      else setAvatarPath('/favicon.ico');
+    }
+  }, []);
   return (
     <Link href={`/dashboard/${localStorage.getItem('userId')}`}>
       <button className="flex items-center">
         <div className="w-[25px] h-[25px] rounded-full overflow-hidden">
-          <Image
-            src={
-              localStorage.getItem('avatarPath')
-                ? `${localStorage.getItem('avatarPath')}`
-                : '/favicon.ico'
-            }
-            width="25px"
-            height="25px"
-          />
+          {isValid ? (
+            <Image
+              src={avatarPath}
+              width="25px"
+              height="25px"
+              onError={() => setIsValid(false)}
+            />
+          ) : (
+            <Image src="/favicon.ico" width="25px" height="25px" />
+          )}
         </div>
         <span className="ml-2">{localStorage.getItem('nickname')}</span>
         <FontAwesomeIcon icon={faChevronRight} />

--- a/client/components/yeonwoo/CarouselAnswers.tsx
+++ b/client/components/yeonwoo/CarouselAnswers.tsx
@@ -16,6 +16,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { useRouter } from 'next/router';
 import axios from 'axios';
+import Link from 'next/link';
 
 const variants = {
   enter: (direction: number) => {
@@ -129,14 +130,16 @@ export const CarouselAnswers = () => {
               className="bg-main-yellow bg-opacity-20 w-[793px] h-[190px] rounded-2xl p-8 relative mb-[72px]"
             >
               <div className="flex justify-between items-start">
-                <div>
-                  <span className="text-2xl text-main-orange">A. </span>
-                  <span className="hover:cursor-pointer text-2xl">
-                    {article.content.length > 30
-                      ? `${article.content.slice(0, 30)}...`
-                      : article.content}
-                  </span>
-                </div>
+                <Link href={`/questions/${article.answerId}`}>
+                  <div>
+                    <span className="text-2xl text-main-orange">A. </span>
+                    <span className="hover:cursor-pointer text-2xl">
+                      {article.content.length > 30
+                        ? `${article.content.slice(0, 30)}...`
+                        : article.content}
+                    </span>
+                  </div>
+                </Link>
                 <div className="flex gap-4">
                   <div className="flex gap-2">
                     <FontAwesomeIcon icon={faComment} size="xs" />

--- a/client/components/yeonwoo/CarouselArticle.tsx
+++ b/client/components/yeonwoo/CarouselArticle.tsx
@@ -17,6 +17,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { useRecoilValue } from 'recoil';
 import { userDashboardAtom } from '../../atomsYW';
+import Link from 'next/link';
 
 const variants = {
   enter: (direction: number) => {
@@ -97,14 +98,16 @@ export const CarouselArticle = () => {
               className="bg-main-yellow bg-opacity-20 w-[793px] h-[190px] rounded-2xl p-8 relative mb-[72px]"
             >
               <div className="flex justify-between items-start">
-                <div>
-                  <span className="text-2xl text-main-orange">Q. </span>
-                  <span className="hover:cursor-pointer text-2xl">
-                    {article.title.length > 30
-                      ? `${article.title.slice(0, 30)}...`
-                      : article.title}
-                  </span>
-                </div>
+                <Link href={`/questions/${article.articleId}`}>
+                  <div>
+                    <span className="text-2xl text-main-orange">Q. </span>
+                    <span className="hover:cursor-pointer text-2xl">
+                      {article.title.length > 30
+                        ? `${article.title.slice(0, 30)}...`
+                        : article.title}
+                    </span>
+                  </div>
+                </Link>
                 <div className="flex gap-4">
                   <div className="flex gap-2">
                     <FontAwesomeIcon icon={faHeart} size="xs" />

--- a/client/components/yeonwoo/CarouselBookmarks.tsx
+++ b/client/components/yeonwoo/CarouselBookmarks.tsx
@@ -16,6 +16,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { useRouter } from 'next/router';
 import axios from 'axios';
+import Link from 'next/link';
 
 const variants = {
   enter: (direction: number) => {
@@ -147,14 +148,16 @@ export const CarouselBookmarks = () => {
               className="bg-main-yellow bg-opacity-20 w-[793px] h-[190px] rounded-2xl p-8 relative mb-[72px]"
             >
               <div className="flex justify-between items-start">
-                <div>
-                  <span className="text-2xl text-main-orange">A. </span>
-                  <span className="hover:cursor-pointer text-2xl">
-                    {article.title.length > 30
-                      ? `${article.title.slice(0, 30)}...`
-                      : article.title}
-                  </span>
-                </div>
+                <Link href={`/questions/${article.articleId}`}>
+                  <div>
+                    <span className="text-2xl text-main-orange">B. </span>
+                    <span className="hover:cursor-pointer text-2xl">
+                      {article.title.length > 30
+                        ? `${article.title.slice(0, 30)}...`
+                        : article.title}
+                    </span>
+                  </div>
+                </Link>
                 <div className="flex gap-4">
                   <div className="flex gap-2">
                     <FontAwesomeIcon icon={faComment} size="xs" />

--- a/client/components/yeonwoo/HallOfFame.tsx
+++ b/client/components/yeonwoo/HallOfFame.tsx
@@ -6,6 +6,7 @@
 
 import axios from 'axios';
 import Image from 'next/image';
+import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { rankList } from '../../interfaces';
 
@@ -58,9 +59,11 @@ export const HallOfFame = () => {
                 </div>
                 <div>
                   <div>
-                    <span className="text-[15px] font-bold">
-                      {rank.nickname}
-                    </span>
+                    <Link href={`/dashboard/${rank.userId}`}>
+                      <span className="text-[15px] font-bold hover:cursor-pointer">
+                        {rank.nickname}
+                      </span>
+                    </Link>
                   </div>
                   <div className="flex justify-between w-[273px]">
                     <div>

--- a/client/components/yeonwoo/ListLately.tsx
+++ b/client/components/yeonwoo/ListLately.tsx
@@ -87,13 +87,19 @@ export const ListLately = () => {
                   key={article.articleId}
                 >
                   <div className="mb-4">
-                    <span className="text-lg font-bold">{article.title}</span>
+                    <Link href={`/questions/${article.articleId}`}>
+                      <span className="text-lg font-bold hover:cursor-pointer">
+                        {article.title}
+                      </span>
+                    </Link>
                   </div>
                   <div className="flex justify-between items-center">
                     <div className="flex">
-                      <span className="text-xs">
-                        {article.userInfo.nickname}
-                      </span>
+                      <Link href={`/dashboard/${article.userInfo.userId}`}>
+                        <span className="text-xs hover:cursor-pointer">
+                          {article.userInfo.nickname}
+                        </span>
+                      </Link>
                     </div>
                     <div className="flex gap-4">
                       <div className="flex">

--- a/client/pages/questions/index.tsx
+++ b/client/pages/questions/index.tsx
@@ -12,7 +12,6 @@ import { Header } from '../../components/common/Header';
 import { LoadMoreButton } from '../../components/haseung/LoadMoreButton';
 import { QuestionList } from '../../components/haseung/QuestionList';
 import { SearchWithTagButton } from '../../components/haseung/SearchWithTagButton';
-import { BtnTag } from '../../components/hyejung/BtnTag';
 
 const Questions: NextPage = () => {
   return (


### PR DESCRIPTION
## 글 작성 버튼
- 글 목록에서 글 작성으로 이동하도록 버튼 생성

## 헤더 아바타 에러 해결
- 로그인 후 유저의 avatar 가 없는 경우 에러가 발생해서 수정했습니다

## 메인 페이지/대시보드 페이지 항목 클릭시 해당 페이지 연결
- 글 제목 클릭시 해당 글 상세 페이지
- 유저 클릭시 해당 유저 대시보드 페이지