### PR TITLE
feat : axios interceptor 를 활용한 리프레시 토큰 갱신 기능 구현

### DIFF
--- a/client/libs/client.ts
+++ b/client/libs/client.ts
@@ -8,14 +8,39 @@ if (typeof window !== 'undefined') {
 export const client = axios.create({
   headers: {
     withCredentials: true,
-    Authorization: `${accessToken}`,
+    Authorization: accessToken,
     'Content-Type': `application/json`,
     'ngrok-skip-browser-warning': '111',
   },
 });
 
+const requestArray: any = [];
+
+client.interceptors.request.use(
+  async (config) => {
+    const accessToken = localStorage.getItem('accessToken');
+    config.headers = {
+      withCredentials: true,
+      Authorization: `${accessToken}`,
+      'Content-Type': `application/json`,
+      'ngrok-skip-browser-warning': '111',
+    };
+    return config;
+  },
+  (error) => {
+    Promise.reject(error);
+  },
+);
+
 client.interceptors.response.use(
   (response) => {
+    if (requestArray.length != 0) {
+      requestArray.forEach(function (x: any, i: any) {
+        if (response.config.url == x.url) {
+          requestArray.splice(i, 1);
+        }
+      });
+    }
     return response;
   },
   async (error) => {
@@ -24,25 +49,32 @@ client.interceptors.response.use(
       response: { status },
     } = error;
     if (status === 401) {
-      if (error.response.data.message === 'TokenExpiredError') {
-        const originalRequest = config;
-        const refreshToken = localStorage.getItem('refreshToken');
-
-        const { data } = await client.put(`/api/auth/token`, {
+      const originalRequest = config;
+      const { data } = await axios.put(
+        `/api/auth/token`,
+        {},
+        {
           headers: {
-            RefreshToken: refreshToken,
+            RefreshToken: localStorage.getItem('refreshToken'),
+            'ngrok-skip-browser-warning': '111',
           },
+        },
+      );
+      const { accessToken: newAccessToken, refreshToken: newRefreshToken } =
+        data;
+      localStorage.setItem('accessToken', newAccessToken);
+      localStorage.setItem('refreshToken', newRefreshToken);
+      if (requestArray.length !== 0) {
+        requestArray.forEach((x: any) => {
+          try {
+            x.headers.Authorization = newAccessToken;
+            client.defaults.headers.common['Authorization'] = newAccessToken;
+          } catch (err) {
+            console.log(err);
+          }
         });
-        const { accessToken: newAccessToken, refreshToken: newRefreshToken } =
-          data;
-        localStorage.setItem('accessToken', newAccessToken);
-        localStorage.setItem('refreshToken', newRefreshToken);
-
-        axios.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`;
-        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
-
-        return axios(originalRequest);
       }
+      return client(originalRequest);
     }
     return Promise.reject(error);
   },

--- a/client/libs/client.ts
+++ b/client/libs/client.ts
@@ -13,3 +13,37 @@ export const client = axios.create({
     'ngrok-skip-browser-warning': '111',
   },
 });
+
+client.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  async (error) => {
+    const {
+      config,
+      response: { status },
+    } = error;
+    if (status === 401) {
+      if (error.response.data.message === 'TokenExpiredError') {
+        const originalRequest = config;
+        const refreshToken = localStorage.getItem('refreshToken');
+
+        const { data } = await client.put(`/api/auth/token`, {
+          headers: {
+            RefreshToken: refreshToken,
+          },
+        });
+        const { accessToken: newAccessToken, refreshToken: newRefreshToken } =
+          data;
+        localStorage.setItem('accessToken', newAccessToken);
+        localStorage.setItem('refreshToken', newRefreshToken);
+
+        axios.defaults.headers.common.Authorization = `Bearer ${newAccessToken}`;
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+
+        return axios(originalRequest);
+      }
+    }
+    return Promise.reject(error);
+  },
+);


### PR DESCRIPTION
### 개요
* 원인은 알 수 없으나 간헐적으로 갱신 요청시 404가 뜨는 현상이 있습니다.
* 현재 추측으로는 여러개의 요청이 중첩되어 들어가다보니 그런 것 같은데, 새로고침을 하면 다시 잘 동작하는 것 확인되었습니다.
* 일단은 한 페이지에서 여러개의 요청이 들어갈 때 제대로 동작하지 않는 것 같아서, `requestArray` 배열 안에 요청을 담아두고 하나씩 처리하는 방식으로 구현했습니다. (구글링의 도움을 많이 받았습니다.)
* 100% 구현된 기능은 아니지만 작업에 필요하시거나, 코드가 궁금하실 수 있을 것 같아 먼저 PR 올리는점 양해부탁드립니다. 

### Todos
* 404가 뜨는 정확한 원인을 파악해보도록 하겠습니다.