### PR TITLE
프로필 수정시 닉네임 중복검사

### DIFF
--- a/client/components/yeonwoo/AsideTop.tsx
+++ b/client/components/yeonwoo/AsideTop.tsx
@@ -13,6 +13,7 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { isLoginAtom, renderingAtom, userDashboardAtom } from '../../atomsYW';
 import { changeGradeEmoji } from '../../libs/changeGradeEmoji';
 import { client } from '../../libs/client';
+import { inspectNicknameDuplication } from '../../libs/inspectNicknameDuplication';
 import { uploadImg } from '../../libs/uploadS3';
 
 export const AsideTop = () => {
@@ -96,6 +97,11 @@ export const AsideTop = () => {
       console.error(error);
     }
   };
+
+  const onBlurNickname = () => {
+    inspectNicknameDuplication(userDashboard.nickname, editNickname);
+  };
+
   return (
     <>
       {isEdit ? (
@@ -150,9 +156,10 @@ export const AsideTop = () => {
               <div className="flex justify-between items-center">
                 <input
                   className="text-xl font-bold border border-main-gray rounded-full pl-4 w-[148px]"
+                  placeholder="닉네임"
                   value={editNickname}
                   onChange={(e) => setEditNickname(e.target.value)}
-                  placeholder="닉네임"
+                  onBlur={onBlurNickname}
                 />
               </div>
               <select

--- a/client/components/yeonwoo/EditProfile.tsx
+++ b/client/components/yeonwoo/EditProfile.tsx
@@ -12,6 +12,7 @@ import { useSetRecoilState } from 'recoil';
 import { dataHeaderAtom, isLoginAtom, renderingAtom } from '../../atomsYW';
 import { userDashboard } from '../../interfaces';
 import { client } from '../../libs/client';
+import { inspectNicknameDuplication } from '../../libs/inspectNicknameDuplication';
 
 interface IChangePassword {
   originalPassword: string;
@@ -148,6 +149,10 @@ export const EditProfileComponent = () => {
       }
     }
   };
+
+  const onBlurNickname = () => {
+    inspectNicknameDuplication(userData?.nickname ?? '', nickname);
+  };
   return (
     <>
       {pathname === '/edit-profile' ? (
@@ -164,6 +169,7 @@ export const EditProfileComponent = () => {
               className="w-full rounded-full h-11 px-4 mt-2 mb-10 border border-main-gray"
               value={nickname}
               onChange={(e) => setNickname(e.target.value)}
+              onBlur={onBlurNickname}
             />
             <label htmlFor="message">메세지</label>
             <input

--- a/client/libs/inspectNicknameDuplication.ts
+++ b/client/libs/inspectNicknameDuplication.ts
@@ -1,0 +1,33 @@
+import { client } from './client';
+
+interface IError {
+  response: {
+    data: {
+      status: number;
+    };
+  };
+}
+export const inspectNicknameDuplication = async (
+  nickname: string,
+  editNickname: string,
+) => {
+  if (nickname !== editNickname) {
+    try {
+      await client.post('/api/auth/nickname', {
+        nickname: editNickname,
+      });
+    } catch (error) {
+      const customError = error as IError;
+      switch (customError.response.data.status) {
+        case 400:
+          alert('닉네임은 최소 1글자, 최대 7글자, 자음, 모음 불가입니다');
+          break;
+        case 409:
+          alert('죄송합니다 중복된 닉네임이네요 😭');
+          break;
+        default:
+          alert('알 수 없는 오류가 다시 시도해 주세요 😭');
+      }
+    }
+  }
+};


### PR DESCRIPTION
- 따로 버튼 생성하지 않고 닉네임 인풋창에서 유저가 벗어날 때 자동으로 API 호출
  - 유저가 닉네임 수정했다가 다시 본인의 닉네임을 적을때 중복된다고 나오기 때문에 수정하려는 닉네임의 상태가 기존 닉네임과 같다면 API 호출 X
- 대시보드 프로필 수정, 개인 정보수정 프로필 수정 페이지 동일하게 적용
- Alert 창 추후 하승님 작업 이후 react-tostify 로 전환하여 UI 개선

![](https://velog.velcdn.com/images/hyeonwooga/post/ce4a4f49-6bda-4d73-a217-db87dfee292d/image.gif)