### PR TITLE
정보글 목록 페이지

### DIFF
--- a/client/components/yeonwoo/InformsList.tsx
+++ b/client/components/yeonwoo/InformsList.tsx
@@ -1,0 +1,94 @@
+/*
+ * 책임 작성자: 박연우
+ * 최초 작성일: 2022-12-11
+ * 최근 수정일: 2022-12-11
+ * 개요: 정보글 리스트를 표시합니다.
+ */
+
+import Link from 'next/link';
+import { QuestionListProps } from '../../libs/interfaces';
+import { elapsedTime } from '../../libs/elapsedTime';
+import { faComment } from '@fortawesome/free-regular-svg-icons';
+import { faHeart } from '@fortawesome/free-solid-svg-icons';
+import { faCircleCheck as voidCheck } from '@fortawesome/free-regular-svg-icons';
+import { faCircleCheck as solidCheck } from '@fortawesome/free-solid-svg-icons';
+
+import { Pagination } from '../haseung/Pagination';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Loader } from '../common/Loader';
+
+export const InformsList = ({
+  response,
+  isLoading,
+  pageIndex,
+  setPageIndex,
+}: any) => {
+  if (!isLoading && response && response.data.length)
+    return (
+      <main className="flex flex-col w-full divide-y min-h-screen">
+        {response.data.map((article: QuestionListProps) => (
+          <section className="py-4 space-y-4 " key={article.articleId}>
+            <article className="space-x-2">
+              <Link href={`/informations/${article.articleId}`}>
+                <span className="text-lg font-bold hover:cursor-pointer">
+                  {article?.title?.length >= 35
+                    ? `${article?.title?.slice(0, 35)}...`
+                    : article?.title}
+                </span>
+              </Link>
+            </article>
+            <section className="flex justify-between items-center">
+              <article className="flex space-x-3">
+                <div className="flex">
+                  <Link href={`/dashboard/${article?.userInfo?.userId}`}>
+                    <span className="text-xs hover:cursor-pointer">
+                      {article?.userInfo?.nickname}
+                    </span>
+                  </Link>
+                </div>
+                <div className="text-xs space-x-2">
+                  {article?.tags?.map((tag, i) => (
+                    <span key={i}>{i < 3 ? `#${tag.name}` : ''}</span>
+                  ))}
+                </div>
+              </article>
+              <article className="flex gap-4">
+                <div className="flex">
+                  <span className="text-xs">
+                    {elapsedTime(article.createdAt)}
+                  </span>
+                </div>
+                <div className="flex gap-2">
+                  <FontAwesomeIcon icon={faHeart} size="xs" />
+                  <span className="text-xs">{article.likes}</span>
+                </div>
+                <div className="flex gap-2">
+                  <FontAwesomeIcon icon={faComment} size="xs" />
+                  <span className="text-xs">{article.commentCount}</span>
+                </div>
+              </article>
+            </section>
+          </section>
+        ))}
+        <div className="mx-auto mt-10">
+          <Pagination
+            setPageIndex={setPageIndex}
+            totalPage={response?.pageInfo?.totalPages}
+            pageIndex={pageIndex}
+          />
+        </div>
+      </main>
+    );
+  else if (!isLoading && !response?.data.length)
+    return (
+      <div className="flex justify-center items-center my-20 text-main-gray w-full h-screen text-base">
+        검색 결과를 찾을 수 없습니다.🥲
+      </div>
+    );
+  else
+    return (
+      <div className="flex justify-center items-center my-20 text-main-gray w-full h-screen text-base">
+        <Loader />
+      </div>
+    );
+};

--- a/client/pages/informations/index.tsx
+++ b/client/pages/informations/index.tsx
@@ -1,0 +1,168 @@
+/*
+ * 책임 작성자: 박연우
+ * 최초 작성일: 2022-12-11
+ * 최근 수정일: 2022-12-11
+ */
+
+import { faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { GetServerSideProps, NextPage } from 'next';
+import { Header } from '../../components/common/Header';
+import { SearchWithTagButton } from '../../components/haseung/SearchWithTagButton';
+import { Footer } from '../../components/common/Footer';
+import { useEffect, useState } from 'react';
+import { useFetch } from '../../libs/useFetchSWR';
+import { useForm, SubmitHandler } from 'react-hook-form';
+import Link from 'next/link';
+import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
+import { useRecoilState } from 'recoil';
+import { keywordAtom } from '../../atomsYW';
+import { useCheckClickIsLogin } from '../../libs/useCheckIsLogin';
+import { Seo } from '../../components/common/Seo';
+import { InformsList } from '../../components/yeonwoo/InformsList';
+
+type FormValue = {
+  keyword: string;
+};
+
+const Questions: NextPage = () => {
+  const [pageIndex, setPageIndex] = useState(1);
+  const [keyword, setKeyword] = useRecoilState(keywordAtom);
+  const [sort, setSort] = useState(['최신순', 'desc']);
+  const [isOpen, setIsOpen] = useState(false);
+  const [target, setTarget] = useState('titleAndContent');
+
+  useEffect(() => {
+    setPageIndex(1);
+    setKeyword('');
+    setSort(['최신순', 'desc']);
+    setTarget('titleAndContent');
+  }, []);
+
+  const { data: response, isLoading } = useFetch(
+    `/api/articles?page=${pageIndex}&size=10&category=INFO&target=${target}&keyword=${keyword}&sort=${sort[1]}`,
+  );
+
+  const { register, handleSubmit } = useForm<FormValue>();
+  const onValid: SubmitHandler<FormValue> = (data) => {
+    setTarget('titleAndContent');
+    if (!data.keyword.length) {
+      setKeyword('');
+      setKeyword('');
+    } else {
+      setKeyword(data.keyword);
+    }
+  };
+
+  const dropdownSortArr = ['최신순', '오래된순', '좋아요순', '댓글많은순'];
+  const handleSort = (e: React.MouseEvent<HTMLElement>) => {
+    const text = (e.target as HTMLLIElement).textContent;
+    switch (text) {
+      case '최신순':
+        setSort([text, 'desc']);
+        break;
+      case '오래된순':
+        setSort([text, 'asc']);
+        break;
+      case '좋아요순':
+        setSort([text, 'like-desc']);
+        break;
+      case '댓글많은순':
+        setSort([text, 'comment-desc']);
+        break;
+    }
+    setIsOpen(false);
+  };
+  const checkIsLogin = useCheckClickIsLogin();
+
+  return (
+    <>
+      <Seo title="질문/답변" />
+      <Header />
+      <main className="max-w-[1280px] mx-auto flex space-x-5 p-8 md:p-16 bg-white shadow-sm border-[1px] border-gray-200">
+        <form
+          className="hidden md:flex flex-col w-full items-center justify-center"
+          onSubmit={handleSubmit(onValid)}
+        >
+          <section className="w-full flex justify-center items-center">
+            <div>
+              <FontAwesomeIcon
+                icon={faMagnifyingGlass}
+                className="relative left-6"
+              />
+            </div>
+            <input
+              type="text"
+              className="justify-center border border-solid border-main-gray rounded-md mr-2 py-1 bg-gray-50 w-64 pl-7 pr-2 placeholder:text-sm"
+              placeholder="검색어를 입력해주세요."
+              {...register('keyword')}
+            />
+            <button className="bg-main-yellow bg-opacity-80 py-1.5 px-4 rounded-md text-font-gray hover:bg-main-yellow hover:opacity-100 transition-all">
+              검색
+            </button>
+          </section>
+          <SearchWithTagButton
+            setKeyword={setKeyword}
+            setTarget={setTarget}
+            keyword={keyword}
+          />
+        </form>
+        <section className="flex flex-col w-full space-y-6">
+          <article className="flex justify-between">
+            <div className="flex flex-col relative">
+              <button
+                className="border border-main-gray rounded-lg py-1.5 w-28"
+                onClick={() => setIsOpen((prev) => !prev)}
+              >
+                {`${sort[0]} `}
+                <FontAwesomeIcon icon={faChevronDown} className="fa-xs" />
+              </button>
+              {isOpen ? (
+                <ul className="bg-white w-full font-bold shadow-md cursor-pointer absolute top-11">
+                  {dropdownSortArr.map((value) => {
+                    return (
+                      <li
+                        value={value}
+                        key={value}
+                        className="p-4 hover:bg-main-yellow transition-all text-center"
+                        onClick={handleSort}
+                      >
+                        {value}
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : null}
+            </div>
+            <Link href="/ask">
+              <button
+                className="bg-main-orange bg-opacity-80 py-1.5 px-4 rounded-md text-font-gray hover:bg-main-orange hover:opacity-100 w-28 transition-all"
+                onClick={checkIsLogin}
+              >
+                질문하기
+              </button>
+            </Link>
+          </article>
+          <InformsList
+            response={response}
+            pageIndex={pageIndex}
+            setPageIndex={setPageIndex}
+            isLoading={isLoading}
+          />
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const content = context.req.url?.split('/')[1];
+  return {
+    props: {
+      content,
+    },
+  };
+};
+
+export default Questions;


### PR DESCRIPTION
- 목록의 제목 부분 채택/미채택 여부 제거
- 정렬 조건 중 채택/미채택 제거
- 해당 글 클릭시 /informations/[articleId] 로 연결
- 기존 질문/답변 글 목록 페이지 재활용
   - api 도 완전 동일하기 때문에 SWR api category 부분만 수정해서 재활용