### PR TITLE
toast 컴포넌트 색상 변경, 카카오 uri 수정, 로딩 컴포넌트 위치 변경

### DIFF
--- a/client/components/common/SocialLoginBtn.tsx
+++ b/client/components/common/SocialLoginBtn.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 export const SocialLoginBtn = () => {
   return (
     <section className="flex w-full justify-center">
-      <Link href="http://morak-873888559.ap-northeast-2.elb.amazonaws.com:8080/oauth2/authorization/kakao">
+      <Link href="https://morak.link/oauth2/authorization/kakao">
         <button className="bg-gray-200 hover:bg-gray-300 cursor-pointer w-full p-3 rounded-[20px]">
           <FontAwesomeIcon
             icon={faComment}

--- a/client/components/dashboard/AsideTop.tsx
+++ b/client/components/dashboard/AsideTop.tsx
@@ -77,7 +77,7 @@ export const AsideTop = () => {
       const file = files && files[0];
       await uploadImg(res.data.preSignedUrl, file);
       setIsClicked(false);
-      toast.error('프로필이 정상적으로 변경되었습니다!');
+      toast.success('프로필이 정상적으로 변경되었습니다!');
       setRenderingHeader((prev) => !prev);
     } catch (error) {
       toast.error('오류가 발생했습니다. 다시 시도해주세요!');

--- a/client/pages/find-password/check-auth-code/index.tsx
+++ b/client/pages/find-password/check-auth-code/index.tsx
@@ -60,14 +60,10 @@ const CheckAuthCode: NextPage = () => {
             className="rounded-full w-96 h-10 pl-4 border"
           />
           <button className="bg-main-yellow bg-opacity-80 py-3 w-full rounded-[20px] font-bold mb-5 hover:bg-main-yellow">
-            임시 비밀번호 발급
+            {isSubmitting ? <Loader /> : '임시 비밀번호 발급'}
           </button>
           <p className="text-center relative top-20 font-bold text-xl">
-            {isSubmitting ? (
-              <>
-                <Loader /> <span>임시 비밀번호 전송 중....</span>
-              </>
-            ) : null}
+            {isSubmitting ? <span>임시 비밀번호 전송 중....</span> : null}
           </p>
         </form>
       </main>

--- a/client/pages/find-password/get-auth-code/index.tsx
+++ b/client/pages/find-password/get-auth-code/index.tsx
@@ -45,14 +45,10 @@ const GetAuthCode: NextPage = () => {
             className="rounded-full w-full h-10 pl-4 border"
           />
           <button className="bg-main-yellow bg-opacity-80 py-3 w-full rounded-[20px] font-bold  hover:bg-main-yellow">
-            인증번호 발송
+            {isSubmitting ? <Loader /> : '인증번호 발송'}
           </button>
           <p className="text-center relative top-20 font-bold text-xl">
-            {isSubmitting ? (
-              <>
-                <Loader /> <span>인증번호 전송 중....</span>
-              </>
-            ) : null}
+            {isSubmitting ? <span>인증번호 전송 중....</span> : null}
           </p>
         </form>
       </main>


### PR DESCRIPTION
- 프로필이 정상적으로 변경되었을 때 나타나는 토스트 컴포넌트의 색깔이 빨간색으로 되어있었어서 초록색(success)으로 변경하였습니다.
- 카카오 리다이렉트 uri 수정하였습니다.
- 임시 비밀번호 발급 및 인증번호 발송 버튼 각각에 로딩 컴포넌트를 배치하였습니다.