### PR TITLE
개인정보 수정 페이지 및 컴포넌트 코드 리팩토링

### DIFF
--- a/client/api/signUpApi.ts
+++ b/client/api/signUpApi.ts
@@ -1,10 +1,11 @@
 import axios from 'axios';
 import { makePostRequest } from './makePostRequest';
 
-type UserCredentials = {
+export type UserCredentials = {
   email: string;
   password: string;
-  confirmPassword: string;
+  confirmPassword?: string;
+  authKey?: string;
   nickname: string;
 };
 

--- a/client/api/signUpApi.ts
+++ b/client/api/signUpApi.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { makePostRequest } from './makePostRequest';
 
-export type UserCredentials = {
+type UserCredentials = {
   email: string;
   password: string;
   confirmPassword?: string;

--- a/client/components/common/Footer/index.tsx
+++ b/client/components/common/Footer/index.tsx
@@ -21,7 +21,7 @@ const developers: Developer[] = [
   {
     name: '정하승',
     github: 'https://github.com/HA-SEUNG-JEONG',
-    blog: 'https://haseungdev-3fhsrdzzv-ha-seung-jeong.vercel.app/',
+    blog: 'https://haseungdev.vercel.app/',
   },
   {
     name: '백시온',

--- a/client/components/common/QuillEditor/Editor.tsx
+++ b/client/components/common/QuillEditor/Editor.tsx
@@ -116,6 +116,8 @@ export const Editor = () => {
       const payload = {
         title,
         content,
+        // isEditing이 true일 경우 fileId를 키로 갖고 아니면 category를 키로 가짐
+        // isEditing이 true면 fileIdList를 value로 갖고 아니면 category를 value로 가짐
         [isEditing ? 'fileId' : 'category']: isEditing ? fileIdList : category,
         tags,
       };

--- a/client/components/dashboard/AsideComponent.tsx
+++ b/client/components/dashboard/AsideComponent.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { AsideBot } from './AsideBot';
+import { AsideMid } from './AsideMid';
+import { AsideTop } from './AsideTop';
+
+const AsideComponent = () => {
+  return (
+    <section className="w-[305px]">
+      <AsideTop />
+      <AsideMid />
+      <AsideBot />
+    </section>
+  );
+};
+
+export default AsideComponent;

--- a/client/components/dashboard/AsideTop.tsx
+++ b/client/components/dashboard/AsideTop.tsx
@@ -61,6 +61,7 @@ export const AsideTop = () => {
         setIsEdit(false);
         setIsClicked(false);
         setRenderingHeader((prev) => !prev);
+        toast.success('프로필이 성공적으로 변경되었습니다.');
       } catch (error) {
         toast.error('에러가 발생했습니다 다시 시도해주세요');
         console.error(error);

--- a/client/components/edit-privacy/AsideEditProfile.tsx
+++ b/client/components/edit-privacy/AsideEditProfile.tsx
@@ -4,6 +4,12 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
+const links = [
+  { href: '/edit-profile', text: '프로필 수정' },
+  { href: '/edit-password', text: '비밀번호 수정' },
+  { href: '/membership-withdrawal', text: '회원 탈퇴' },
+];
+
 export const AsideEditProfile = () => {
   const [pathname, setPathname] = useState('');
   const router = useRouter();
@@ -15,42 +21,20 @@ export const AsideEditProfile = () => {
   }, []);
   return (
     <>
-      <Link href="/edit-profile">
-        <div
-          className={`w-full px-4 py-3 flex items-baseline hover:cursor-pointer ${
-            pathname === '/edit-profile'
-              ? 'border-main-yellow bg-[#D9D9D9] border-l-4'
-              : 'border-transparent'
-          }`}
-        >
-          <FontAwesomeIcon icon={faUser} />
-          <span className="ml-4 text-lg">프로필 수정</span>
-        </div>
-      </Link>
-      <Link href="edit-password">
-        <div
-          className={`w-full px-4 py-3 flex items-baseline hover:cursor-pointer ${
-            pathname === '/edit-password'
-              ? 'border-main-yellow bg-[#D9D9D9] border-l-4'
-              : 'border-transparent'
-          }`}
-        >
-          <FontAwesomeIcon icon={faUser} />
-          <span className="ml-4 text-lg">비밀번호 수정</span>
-        </div>
-      </Link>
-      <Link href="/membership-withdrawal">
-        <div
-          className={`w-full px-4 py-3 flex items-baseline hover:cursor-pointer ${
-            pathname === '/membership-withdrawal'
-              ? 'border-main-yellow bg-[#D9D9D9] border-l-4'
-              : 'border-transparent'
-          }`}
-        >
-          <FontAwesomeIcon icon={faUser} />
-          <span className="ml-4 text-lg">회원 탈퇴</span>
-        </div>
-      </Link>
+      {links.map((link) => (
+        <Link key={link.href} href={link.href}>
+          <div
+            className={`w-full px-4 py-3 flex items-baseline hover:cursor-pointer ${
+              pathname === link.href
+                ? 'border-main-yellow bg-[#D9D9D9] border-l-4'
+                : 'border-transparent'
+            }`}
+          >
+            <FontAwesomeIcon icon={faUser} />
+            <span className="ml-4 text-lg">{link.text}</span>
+          </div>
+        </Link>
+      ))}
     </>
   );
 };

--- a/client/components/login/LoginForm/index.tsx
+++ b/client/components/login/LoginForm/index.tsx
@@ -49,7 +49,9 @@ export const LoginForm = () => {
       router.push('/');
     } catch (err) {
       console.error(err);
-      toast.error('로그인에 실패했습니다! 다시 한 번 확인해주세요.🥲');
+      toast.error(
+        '로그인에 실패했습니다! 아이디 혹은 비밀번호를 다시 확인해주세요.🥲',
+      );
     } finally {
       setIsSubmitting(false);
     }

--- a/client/components/main/ListLately.tsx
+++ b/client/components/main/ListLately.tsx
@@ -25,11 +25,11 @@ export const ListLately = () => {
 
   return (
     <>
-      <div className="mb-6">
+      <div className="mb-6 ">
         <Link href="/questions">
-          <span className="text-2xl mr-2 font-bold hover:cursor-pointer hover:opacity-50">
+          <div className="text-2xl mr-2 font-bold hover:cursor-pointer hover:opacity-50 inline-block select-none">
             ❓ 최근 질문
-          </span>
+          </div>
         </Link>
         <Link href="/questions">
           <span className="text-xs hover:cursor-pointer hover:opacity-40">

--- a/client/components/main/ListLately.tsx
+++ b/client/components/main/ListLately.tsx
@@ -25,13 +25,19 @@ export const ListLately = () => {
 
   return (
     <>
-      <div className="mb-6 ">
-        <span className="text-2xl mr-2 font-bold">❓ 최근 질문</span>
+      <div className="mb-6">
         <Link href="/questions">
-          <span className="text-xs hover:cursor-pointer">더보기 ＞</span>
+          <span className="text-2xl mr-2 font-bold hover:cursor-pointer hover:opacity-50">
+            ❓ 최근 질문
+          </span>
+        </Link>
+        <Link href="/questions">
+          <span className="text-xs hover:cursor-pointer hover:opacity-40">
+            더보기 ＞
+          </span>
         </Link>
         <Link href="/post">
-          <span className="text-xs ml-4 hover:cursor-pointer">
+          <span className="text-xs ml-4 hover:cursor-pointer hover:opacity-40">
             📝 질문 작성 ＞
           </span>
         </Link>
@@ -42,7 +48,7 @@ export const ListLately = () => {
             {data &&
               data.slice(0, 5).map((article) => (
                 <div
-                  className="w-[492px] h-18 border-b mb-8"
+                  className="w-[492px] h-18 border-b mb-8 hover:bg-gray-100 cursor-pointer"
                   key={article.articleId}
                 >
                   <div className="mb-4">
@@ -92,7 +98,7 @@ export const ListLately = () => {
             {data &&
               data.slice(5).map((article) => (
                 <div
-                  className="w-[492px] h-18 border-b mb-8"
+                  className="w-[492px] h-18 border-b mb-8 hover:bg-gray-100 cursor-pointer"
                   key={article.articleId}
                 >
                   <div className="mb-4">

--- a/client/components/questions/QuestionList/index.tsx
+++ b/client/components/questions/QuestionList/index.tsx
@@ -26,8 +26,11 @@ export const QuestionList = ({
     return (
       <main className="flex flex-col w-full divide-y min-h-screen">
         {response.data.map((article: ArticleListProps) => (
-          <section className="py-4 space-y-4 " key={article.articleId}>
-            <article className="space-x-2">
+          <section
+            className="py-4 space-y-4 hover:bg-gray-100 cursor-pointer"
+            key={article.articleId}
+          >
+            <article className="space-x-2 ">
               {article.isClosed ? (
                 <FontAwesomeIcon
                   icon={solidCheck}

--- a/client/components/questions/QuestionList/index.tsx
+++ b/client/components/questions/QuestionList/index.tsx
@@ -26,60 +26,60 @@ export const QuestionList = ({
     return (
       <main className="flex flex-col w-full divide-y min-h-screen">
         {response.data.map((article: ArticleListProps) => (
-          <section
-            className="py-4 space-y-4 hover:bg-gray-100 cursor-pointer"
-            key={article.articleId}
-          >
-            <article className="space-x-2 ">
-              {article.isClosed ? (
-                <FontAwesomeIcon
-                  icon={solidCheck}
-                  className="fa-lg text-main-orange"
-                />
-              ) : (
-                <FontAwesomeIcon icon={voidCheck} className="fa-lg" />
-              )}
+          <Link href={`/questions/${article.articleId}`}>
+            <section
+              className="py-4 space-y-4 hover:cursor-pointer hover:bg-gray-100"
+              key={article.articleId}
+            >
+              <article className="space-x-2">
+                {article.isClosed ? (
+                  <FontAwesomeIcon
+                    icon={solidCheck}
+                    className="fa-lg text-main-orange"
+                  />
+                ) : (
+                  <FontAwesomeIcon icon={voidCheck} className="fa-lg" />
+                )}
 
-              <Link href={`/questions/${article.articleId}`}>
                 <span className="text-lg font-bold hover:cursor-pointer">
                   {article?.title?.length >= 35
                     ? `${article?.title?.slice(0, 35)}...`
                     : article?.title}
                 </span>
-              </Link>
-            </article>
-            <section className="flex justify-between items-center">
-              <article className="flex space-x-3">
-                <div className="flex">
-                  <Link href={`/dashboard/${article?.userInfo?.userId}`}>
-                    <span className="text-xs hover:cursor-pointer">
-                      {article?.userInfo?.nickname}
+              </article>
+              <section className="flex justify-between items-center">
+                <article className="flex space-x-3">
+                  <div className="flex">
+                    <Link href={`/dashboard/${article?.userInfo?.userId}`}>
+                      <span className="text-xs hover:cursor-pointer">
+                        {article?.userInfo?.nickname}
+                      </span>
+                    </Link>
+                  </div>
+                  <div className="text-xs space-x-2">
+                    {article?.tags?.map((tag, i) => (
+                      <span key={i}>{i < 3 ? `#${tag.name}` : ''}</span>
+                    ))}
+                  </div>
+                </article>
+                <article className="flex gap-4">
+                  <div className="flex">
+                    <span className="text-xs">
+                      {elapsedTime(article.createdAt)}
                     </span>
-                  </Link>
-                </div>
-                <div className="text-xs space-x-2">
-                  {article?.tags?.map((tag, i) => (
-                    <span key={i}>{i < 3 ? `#${tag.name}` : ''}</span>
-                  ))}
-                </div>
-              </article>
-              <article className="flex gap-4">
-                <div className="flex">
-                  <span className="text-xs">
-                    {elapsedTime(article.createdAt)}
-                  </span>
-                </div>
-                <div className="flex gap-2">
-                  <FontAwesomeIcon icon={faHeart} size="xs" />
-                  <span className="text-xs">{article.likes}</span>
-                </div>
-                <div className="flex gap-2">
-                  <FontAwesomeIcon icon={faComment} size="xs" />
-                  <span className="text-xs">{article.answerCount}</span>
-                </div>
-              </article>
+                  </div>
+                  <div className="flex gap-2">
+                    <FontAwesomeIcon icon={faHeart} size="xs" />
+                    <span className="text-xs">{article.likes}</span>
+                  </div>
+                  <div className="flex gap-2">
+                    <FontAwesomeIcon icon={faComment} size="xs" />
+                    <span className="text-xs">{article.answerCount}</span>
+                  </div>
+                </article>
+              </section>
             </section>
-          </section>
+          </Link>
         ))}
         <div className="mx-auto mt-10">
           <Pagination

--- a/client/components/questions/QuestionList/index.tsx
+++ b/client/components/questions/QuestionList/index.tsx
@@ -13,6 +13,9 @@ import { elapsedTime } from '@libs/elapsedTime';
 import { Pagination } from '@components/common/Pagination';
 import { Loader } from '@components/common/Loader';
 
+const className =
+  'flex justify-center items-center my-20 text-main-gray w-full h-screen text-base';
+
 export const QuestionList = ({
   response,
   isLoading,
@@ -85,14 +88,10 @@ export const QuestionList = ({
       </main>
     );
   else if (!isLoading && !response?.data.length)
-    return (
-      <div className="flex justify-center items-center my-20 text-main-gray w-full h-screen text-base">
-        검색 결과를 찾을 수 없습니다.🥲
-      </div>
-    );
+    return <div className={className}>검색 결과를 찾을 수 없습니다.🥲</div>;
   else
     return (
-      <div className="flex justify-center items-center my-20 text-main-gray w-full h-screen text-base">
+      <div className={className}>
         <Loader />
       </div>
     );

--- a/client/components/questions/SearchWithTagButton/index.tsx
+++ b/client/components/questions/SearchWithTagButton/index.tsx
@@ -1,3 +1,5 @@
+import { SetterOrUpdater } from 'recoil';
+
 const tags = [
   { tagId: 0, name: 'JAVA' },
   { tagId: 1, name: 'C' },
@@ -21,10 +23,24 @@ const tags = [
   { tagId: 19, name: 'TYPESCRIPT' },
 ];
 
+type KeyProps = {
+  setKeyword: SetterOrUpdater<string>;
+  setTarget: React.Dispatch<React.SetStateAction<string>>;
+  keyword: string;
+};
+
 const getTagList = () => {
-  const tagList = [];
-  for (let i = 0; i < tags.length; i += 3) {
-    tagList.push(tags.slice(i, i + 3));
+  const tagList: { tagId: number; name: string }[][] = [];
+  let currentList: { tagId: number; name: string }[] = [];
+  tags.forEach((tag, index) => {
+    currentList.push(tag);
+    if ((index + 1) % 3 === 0) {
+      tagList.push(currentList);
+      currentList = [];
+    }
+  });
+  if (currentList.length > 0) {
+    tagList.push(currentList);
   }
   return tagList;
 };
@@ -33,7 +49,7 @@ export const SearchWithTagButton = ({
   setKeyword,
   setTarget,
   keyword,
-}: any) => {
+}: KeyProps) => {
   const tagList = getTagList();
   return (
     <section className="flex flex-col mt-8 justify-center space-y-6">

--- a/client/components/questions/SearchWithTagButton/index.tsx
+++ b/client/components/questions/SearchWithTagButton/index.tsx
@@ -30,18 +30,18 @@ type KeyProps = {
 };
 
 const getTagList = () => {
-  const tagList: { tagId: number; name: string }[][] = [];
+  const tagList: { tagId: number; name: string }[][] = [[]];
   let currentList: { tagId: number; name: string }[] = [];
+
   tags.forEach((tag, index) => {
     currentList.push(tag);
+    // 3개 태그가 들어갔을 때 tagList에 currentList 집어넣고
     if ((index + 1) % 3 === 0) {
       tagList.push(currentList);
-      currentList = [];
+      currentList = []; // currentList는 빈 배열로 초기화
     }
   });
-  if (currentList.length > 0) {
-    tagList.push(currentList);
-  }
+  if (currentList.length > 0) tagList.push(currentList);
   return tagList;
 };
 

--- a/client/components/questions/SearchWithTagButton/index.tsx
+++ b/client/components/questions/SearchWithTagButton/index.tsx
@@ -30,18 +30,10 @@ type KeyProps = {
 };
 
 const getTagList = () => {
-  const tagList: { tagId: number; name: string }[][] = [[]];
-  let currentList: { tagId: number; name: string }[] = [];
-
-  tags.forEach((tag, index) => {
-    currentList.push(tag);
-    // 3개 태그가 들어갔을 때 tagList에 currentList 집어넣고
-    if ((index + 1) % 3 === 0) {
-      tagList.push(currentList);
-      currentList = []; // currentList는 빈 배열로 초기화
-    }
-  });
-  if (currentList.length > 0) tagList.push(currentList);
+  const tagList = [];
+  for (let i = 0; i < tags.length; i += 3) {
+    tagList.push(tags.slice(i, i + 3));
+  }
   return tagList;
 };
 

--- a/client/components/questions/question-detail/AnswerContent/AnswerEditor.tsx
+++ b/client/components/questions/question-detail/AnswerContent/AnswerEditor.tsx
@@ -67,6 +67,10 @@ export const AnswerEditor = () => {
   // 화면에 출력할 사용자 입력 데이터
   const editorContent = watch('content');
   const handleChange = (value: string) => {
+    if (Boolean(checkIsLogin)) {
+      toast.error('로그인이 필요한 서비스입니다.');
+      router.push('/login');
+    }
     setValue('content', value === '<p><br></p>' ? '' : value);
     trigger('content');
   };
@@ -122,16 +126,11 @@ export const AnswerEditor = () => {
     if (isLogin) {
       if (isAnserEdit.isEdit) patchAnswer(data);
       else postAnswer(data);
-    } else {
-      checkIsLogin();
-    }
+    } else checkIsLogin();
   };
   const onInvalid: SubmitErrorHandler<FormValue> = (data) => {
-    if (isLogin) {
-      toast.error(data.content?.message);
-    } else {
-      checkIsLogin();
-    }
+    if (isLogin) toast.error(data.content?.message);
+    else checkIsLogin();
   };
 
   // Quill 에디터 & 이미지 업로드 관련 코드

--- a/client/components/questions/question-detail/AnswerContent/AnswerEditor.tsx
+++ b/client/components/questions/question-detail/AnswerContent/AnswerEditor.tsx
@@ -83,7 +83,7 @@ export const AnswerEditor = () => {
     const newAnswers = response.data;
     mutate({ currAnswers, ...newAnswers }, { revalidate: false })
       .then(() => {
-        toast.success('답변이 등록되었습니다!');
+        toast.success('답변이 성공적으로 등록되었습니다!');
         isAnswerPosted(true);
         setValue('content', '');
         trigger('content');

--- a/client/components/questions/question-detail/AnswerContent/index.tsx
+++ b/client/components/questions/question-detail/AnswerContent/index.tsx
@@ -21,6 +21,7 @@ import { changeGradeEmoji } from '@libs/changeGradeEmoji';
 import { elapsedTime } from '@libs/elapsedTime';
 import { BtnLike } from '@components/common/BtnLike';
 import { toast } from 'react-toastify';
+import { confirmAlert } from 'react-confirm-alert';
 
 // 기본 이미지 생성 전 임시
 const tempSrc =
@@ -55,18 +56,29 @@ export const AnswerContent = ({ answer, isClosed, pageInfo }: AnswerProps) => {
   }, [isAnswerEdit]);
 
   const onDelete = () => {
-    if (confirm('정말 답변을 삭제하시겠습니까..?')) {
-      client
-        .delete(`/api/articles/${articleId}/answers/${answer.answerId}`)
-        .then(() => {
-          toast.success('삭제가 완료되었습니다!');
-          mutate(`/api/articles/${articleId}/answers?page=1&size=5`);
-        })
-        .catch((err) => {
-          console.error(err);
-          toast.error('답변 삭제에 실패했습니다.');
-        });
-    }
+    confirmAlert({
+      message: '정말 답변을 삭제하시겠습니까?',
+      buttons: [
+        {
+          label: 'YES',
+          onClick: async () => {
+            try {
+              await client.delete(
+                `/api/articles/${articleId}/answers/${answer.answerId}`,
+              );
+              toast.success('삭제가 완료되었습니다!');
+              mutate(`/api/articles/${articleId}/answers?page=1&size=5`);
+            } catch (error) {
+              console.error(error);
+              toast.error('답변 삭제에 실패했습니다.');
+            }
+          },
+        },
+        {
+          label: 'NO',
+        },
+      ],
+    });
   };
 
   const setIsAnswerEdit = useSetRecoilState(isAnswerEditAtom);

--- a/client/components/questions/question-detail/Comment/CommentTextArea.tsx
+++ b/client/components/questions/question-detail/Comment/CommentTextArea.tsx
@@ -13,6 +13,7 @@ import { renderingAtom } from '@atoms/renderingAtom';
 import { useCheckClickIsLogin } from '@libs/useCheckIsLogin';
 import { client } from '@libs/client';
 import { toast } from 'react-toastify';
+import { confirmAlert } from 'react-confirm-alert';
 
 type TextAreaProps = {
   answerId?: number;
@@ -33,9 +34,20 @@ export const CommentTextArea = ({ answerId }: TextAreaProps) => {
   const { register, handleSubmit, watch, setValue } = useForm<FormValue>();
 
   if (watch().content?.length >= 1 && !isLogin) {
-    if (confirm('로그인이 필요한 서비스 입니다. 바로 로그인 하시겠어요?')) {
-      router.push('/login');
-    }
+    confirmAlert({
+      message: '로그인이 필요한 서비스 입니다. 바로 로그인 하시겠어요?',
+      buttons: [
+        {
+          label: 'YES',
+          onClick: () => {
+            router.push('/login');
+          },
+        },
+        {
+          label: 'NO',
+        },
+      ],
+    });
   }
 
   // answerId 가 있는 경우 댓글 코멘트 작성 api 로 요청

--- a/client/components/questions/question-detail/QuestionContent/QuestionContent.tsx
+++ b/client/components/questions/question-detail/QuestionContent/QuestionContent.tsx
@@ -42,7 +42,7 @@ export const QuestionContent = ({
     getLikeBookmark();
   }, []);
 
-  let currUserId: any = '';
+  let currUserId: string | null = '';
   if (typeof window !== 'undefined') {
     currUserId = localStorage.getItem('userId');
   }
@@ -54,7 +54,7 @@ export const QuestionContent = ({
       client
         .delete(`/api/articles/${articleId}`)
         .then(() => {
-          toast.success('게시글이 삭제되었습니다. 게시글 목록으로 돌아갑니다.');
+          toast.success('게시글이 삭제되었습니다.');
           router.replace(`/questions`);
         })
         .catch((err) => {
@@ -124,7 +124,7 @@ export const QuestionContent = ({
         </section>
 
         <section className="space-y-3 border-l pl-4">
-          <CommentContainer commentPreview={article.comments?.[0]} />
+          <CommentContainer />
         </section>
       </>
     </main>

--- a/client/components/questions/question-detail/QuestionContent/QuestionContent.tsx
+++ b/client/components/questions/question-detail/QuestionContent/QuestionContent.tsx
@@ -18,6 +18,7 @@ import { ArticleDetail } from '@type/article';
 
 import { client } from '@libs/client';
 import { toast } from 'react-toastify';
+import { confirmAlert } from 'react-confirm-alert';
 
 type QuestionContentProps = {
   articleId: string;
@@ -50,18 +51,30 @@ export const QuestionContent = ({
   const isClosed = article.isClosed;
 
   const onDelete = () => {
-    if (confirm('게시글을 삭제하시겠습니까...?')) {
-      client
-        .delete(`/api/articles/${articleId}`)
-        .then(() => {
-          toast.success('게시글이 삭제되었습니다.');
-          router.replace(`/questions`);
-        })
-        .catch((err) => {
-          console.log(err);
-          toast.error('답변 삭제에 실패했습니다.');
-        });
-    }
+    confirmAlert({
+      message: '게시글을 삭제하시겠습니까?',
+      buttons: [
+        {
+          label: 'YES',
+          onClick: async () => {
+            try {
+              await client.delete(`/api/articles/${articleId}`);
+              toast.success('게시글이 삭제되었습니다.');
+              router.replace(`/questions`);
+            } catch (error) {
+              console.log(error);
+              toast.error('답변 삭제에 실패했습니다.');
+            }
+          },
+        },
+        {
+          label: 'NO',
+          onClick: () => {
+            return;
+          },
+        },
+      ],
+    });
   };
 
   const onEdit = () => {

--- a/client/components/signup/SignupForm/index.tsx
+++ b/client/components/signup/SignupForm/index.tsx
@@ -51,7 +51,7 @@ export const SignUpForm = () => {
     }
     try {
       router.push('/signup-email');
-      signUpWithEmail(email, password, confirmPassword, nickname);
+      signUpWithEmail({ email, password, confirmPassword, nickname });
       setEmail(email);
       setPassword(password);
       setNickName(nickname);

--- a/client/libs/useCheckIsLogin.ts
+++ b/client/libs/useCheckIsLogin.ts
@@ -18,6 +18,7 @@ export const useCheckClickIsLogin = () => {
           },
           {
             label: 'NO',
+            onClick: () => router.back(),
           },
         ],
       });

--- a/client/libs/useCheckIsLogin.ts
+++ b/client/libs/useCheckIsLogin.ts
@@ -1,3 +1,4 @@
+import { confirmAlert } from 'react-confirm-alert';
 import { useRouter } from 'next/router';
 import { useRecoilValue } from 'recoil';
 
@@ -7,11 +8,19 @@ export const useCheckClickIsLogin = () => {
   const isLogin = useRecoilValue(isLoginAtom);
   const router = useRouter();
   const checkIsLogin = () => {
-    if (
-      !isLogin &&
-      confirm('로그인이 필요한 서비스 입니다. 바로 로그인 하시겠어요?')
-    ) {
-      router.replace('/login');
+    if (!isLogin) {
+      confirmAlert({
+        message: '로그인이 필요한 서비스 입니다. 바로 로그인 하시겠어요?',
+        buttons: [
+          {
+            label: 'YES',
+            onClick: () => router.push('/login'),
+          },
+          {
+            label: 'NO',
+          },
+        ],
+      });
     }
   };
 

--- a/client/pages/dashboard/[userId]/ defaultUserDashboard.ts
+++ b/client/pages/dashboard/[userId]/ defaultUserDashboard.ts
@@ -1,0 +1,24 @@
+export const defaultAvatar = {
+  avatarId: 0,
+  filename: '',
+  remotePath: '/favicon.ico',
+};
+
+export const defaultUserDashboard = {
+  userId: 0,
+  email: '',
+  nickname: '탈퇴한 유저',
+  jobType: '',
+  grade: '',
+  point: 0,
+  github: '',
+  blog: '',
+  infoMessage: '',
+  rank: 0,
+  avatar: defaultAvatar,
+  tags: [],
+  reviewBadges: [],
+  articles: [],
+  activities: [],
+  reviews: [],
+};

--- a/client/pages/dashboard/[userId]/answers.tsx
+++ b/client/pages/dashboard/[userId]/answers.tsx
@@ -10,17 +10,22 @@ import { userDashboardAtom } from '@atoms/userAtom';
 import { Footer } from '@components/common/Footer';
 import { Header } from '@components/common/Header';
 import { Seo } from '@components/common/Seo';
-import { AsideBot } from '@components/dashboard/AsideBot';
-import { AsideMid } from '@components/dashboard/AsideMid';
-import { AsideTop } from '@components/dashboard/AsideTop';
 import { CarouselAnswers } from '@components/dashboard/CarouselAnswers';
 import { CarouselReview } from '@components/dashboard/CarouselReview';
 
 import { client } from '@libs/client';
 
+import AsideComponent from '@components/dashboard/AsideComponent';
+import { defaultAvatar, defaultUserDashboard } from './ defaultUserDashboard';
+
+const className = 'border-b-2 py-4 pr-6';
+const cursorClassName = 'text-xl font-semibold hover:cursor-pointer';
+
 const DashboardAnswers: NextPage = () => {
   const rendering = useRecoilValue(renderingAtom);
   const [userDashboard, setUserDashboard] = useRecoilState(userDashboardAtom);
+  const setDefaultUserDashboard = () =>
+    setUserDashboard(defaultAvatar && defaultUserDashboard);
   const [userId, setUserId] = useState<string | string[] | undefined>('');
   const router = useRouter();
   const getUser = async () => {
@@ -30,28 +35,7 @@ const DashboardAnswers: NextPage = () => {
         setUserDashboard(res.data);
       }
     } catch (error) {
-      setUserDashboard({
-        userId: 0,
-        email: '',
-        nickname: '탈퇴한 유저',
-        jobType: '',
-        grade: '',
-        point: 0,
-        github: '',
-        blog: '',
-        infoMessage: '',
-        rank: 0,
-        avatar: {
-          avatarId: 0,
-          filename: '',
-          remotePath: '/favicon.ico',
-        },
-        tags: [],
-        reviewBadges: [],
-        articles: [],
-        activities: [],
-        reviews: [],
-      });
+      setDefaultUserDashboard();
     }
   };
 
@@ -74,42 +58,32 @@ const DashboardAnswers: NextPage = () => {
       />
       <Header />
       <main className="w-[1280px] min-h-screen mx-auto flex gap-12 mb-12">
-        <div className="w-[305px]">
-          <AsideTop />
-          <AsideMid />
-          <AsideBot />
-        </div>
-        <div className="w-full">
+        <AsideComponent />
+        <article className="w-full">
           {/* <Grass /> */}
-          <div className="mb-8 flex items-baseline">
-            <div className="border-b-2 py-4 pr-6">
+          <section className="mb-8 flex items-baseline">
+            <div className={className}>
               <Link href={`/dashboard/${router.query.userId}`}>
-                <span className="text-xl font-semibold hover:cursor-pointer">
-                  ❓ 나의 질문
-                </span>
+                <span className={cursorClassName}>❓ 나의 질문</span>
               </Link>
             </div>
-            <div className="border-b-2 py-4 pr-6 border-main-orange">
+            <div className={`border-main-orange ${className}`}>
               <Link href={`/dashboard/${router.query.userId}/answers`}>
-                <span className="text-xl font-semibold hover:cursor-pointer">
-                  ❗ 나의 답변
-                </span>
+                <span className={cursorClassName}>❗ 나의 답변</span>
               </Link>
             </div>
-            <div className="border-b-2 py-4 pr-6">
+            <div className={className}>
               <Link href={`/dashboard/${router.query.userId}/bookmarks`}>
-                <span className="text-xl font-semibold hover:cursor-pointer">
-                  🔖 북마크
-                </span>
+                <span className={cursorClassName}>🔖 북마크</span>
               </Link>
             </div>
-          </div>
+          </section>
           <CarouselAnswers />
           <div className="mt-20 mb-8">
             <span className="text-xl font-semibold">☀️ 응원 메세지</span>
           </div>
           <CarouselReview />
-        </div>
+        </article>
       </main>
       <Footer />
     </>

--- a/client/pages/dashboard/[userId]/bookmarks.tsx
+++ b/client/pages/dashboard/[userId]/bookmarks.tsx
@@ -12,15 +12,19 @@ import { client } from '@libs/client';
 import { Footer } from '@components/common/Footer';
 import { Header } from '@components/common/Header';
 import { Seo } from '@components/common/Seo';
-import { AsideBot } from '@components/dashboard/AsideBot';
-import { AsideMid } from '@components/dashboard/AsideMid';
-import { AsideTop } from '@components/dashboard/AsideTop';
 import { CarouselBookmarks } from '@components/dashboard/CarouselBookmarks';
 import { CarouselReview } from '@components/dashboard/CarouselReview';
+import { defaultAvatar, defaultUserDashboard } from './ defaultUserDashboard';
+import AsideComponent from '@components/dashboard/AsideComponent';
+
+const className = 'text-xl font-semibold hover:cursor-pointer';
 
 const DashboardBookmarks: NextPage = () => {
   const rendering = useRecoilValue(renderingAtom);
   const [userDashboard, setUserDashboard] = useRecoilState(userDashboardAtom);
+  const setDefaultUserDashboard = () => {
+    setUserDashboard(defaultAvatar && defaultUserDashboard);
+  };
   const [userId, setUserId] = useState<string | string[] | undefined>('');
   const router = useRouter();
   const getUser = async () => {
@@ -30,28 +34,7 @@ const DashboardBookmarks: NextPage = () => {
         setUserDashboard(res.data);
       }
     } catch (error) {
-      setUserDashboard({
-        userId: 0,
-        email: '',
-        nickname: '탈퇴한 유저',
-        jobType: '',
-        grade: '',
-        point: 0,
-        github: '',
-        blog: '',
-        infoMessage: '',
-        rank: 0,
-        avatar: {
-          avatarId: 0,
-          filename: '',
-          remotePath: '/favicon.ico',
-        },
-        tags: [],
-        reviewBadges: [],
-        articles: [],
-        activities: [],
-        reviews: [],
-      });
+      setDefaultUserDashboard();
     }
   };
 
@@ -74,26 +57,18 @@ const DashboardBookmarks: NextPage = () => {
       />
       <Header />
       <main className="w-[1280px] min-h-screen mx-auto flex gap-12 mb-12">
-        <div className="w-[305px]">
-          <AsideTop />
-          <AsideMid />
-          <AsideBot />
-        </div>
+        <AsideComponent />
         <div className="w-full">
           {/* <Grass /> */}
           <div className="mb-8 flex items-baseline">
             <div className="border-b-2 py-4 pr-6">
               <Link href={`/dashboard/${router.query.userId}`}>
-                <span className="text-xl font-semibold hover:cursor-pointer">
-                  ❓ 나의 질문
-                </span>
+                <span className={className}>❓ 나의 질문</span>
               </Link>
             </div>
             <div className="border-b-2 py-4 pr-6">
               <Link href={`/dashboard/${router.query.userId}/answers`}>
-                <span className="text-xl font-semibold hover:cursor-pointer">
-                  ❗ 나의 답변
-                </span>
+                <span className={className}>❗ 나의 답변</span>
               </Link>
             </div>
             <div className="border-b-2 py-4 pr-6 border-main-orange">

--- a/client/pages/dashboard/[userId]/index.tsx
+++ b/client/pages/dashboard/[userId]/index.tsx
@@ -10,19 +10,21 @@ import { userDashboardAtom } from '@atoms/userAtom';
 import { Footer } from '@components/common/Footer';
 import { Header } from '@components/common/Header';
 import { Seo } from '@components/common/Seo';
-import { AsideBot } from '@components/dashboard/AsideBot';
-import { AsideMid } from '@components/dashboard/AsideMid';
-import { AsideTop } from '@components/dashboard/AsideTop';
 import { CarouselArticle } from '@components/dashboard/CarouselArticle';
 import { CarouselReview } from '@components/dashboard/CarouselReview';
 
 import { client } from '@libs/client';
+import { defaultAvatar, defaultUserDashboard } from './ defaultUserDashboard';
+import AsideComponent from '@components/dashboard/AsideComponent';
 
 const Dashboard: NextPage = () => {
   const rendering = useRecoilValue(renderingAtom);
   const [userDashboard, setUserDashboard] = useRecoilState(userDashboardAtom);
   const [userId, setUserId] = useState<string | string[] | undefined>('');
   const router = useRouter();
+  const setDefaultUserDashboard = () => {
+    setUserDashboard(defaultAvatar && defaultUserDashboard);
+  };
   const getUser = async () => {
     try {
       if (userId) {
@@ -30,28 +32,7 @@ const Dashboard: NextPage = () => {
         setUserDashboard(res.data);
       }
     } catch (error) {
-      setUserDashboard({
-        userId: 0,
-        email: '',
-        nickname: '탈퇴한 유저',
-        jobType: '',
-        grade: '',
-        point: 0,
-        github: '',
-        blog: '',
-        infoMessage: '',
-        rank: 0,
-        avatar: {
-          avatarId: 0,
-          filename: '',
-          remotePath: '/favicon.ico',
-        },
-        tags: [],
-        reviewBadges: [],
-        articles: [],
-        activities: [],
-        reviews: [],
-      });
+      setDefaultUserDashboard();
     }
   };
 
@@ -62,6 +43,8 @@ const Dashboard: NextPage = () => {
   useEffect(() => {
     getUser();
   }, [userId, rendering]);
+
+  const className = 'text-xl font-semibold hover:cursor-pointer';
 
   return (
     <>
@@ -74,26 +57,18 @@ const Dashboard: NextPage = () => {
       />
       <Header />
       <main className="w-[1280px] min-h-screen mx-auto flex gap-12 mb-12">
-        <div className="w-[305px]">
-          <AsideTop />
-          <AsideMid />
-          <AsideBot />
-        </div>
+        <AsideComponent />
         <div className="w-full">
           {/* <Grass /> */}
           <div className="mb-8 flex items-baseline">
             <div className="border-b-2 border-main-orange py-4 pr-6">
               <Link href={`/dashboard/${router.query.userId}`}>
-                <span className="text-xl font-semibold hover:cursor-pointer">
-                  ❓ 나의 질문
-                </span>
+                <span className={className}>❓ 나의 질문</span>
               </Link>
             </div>
             <div className="border-b-2 py-4 pr-6">
               <Link href={`/dashboard/${router.query.userId}/answers`}>
-                <span className="text-xl font-semibold hover:cursor-pointer">
-                  ❗ 나의 답변
-                </span>
+                <span className={className}>❗ 나의 답변</span>
               </Link>
             </div>
             <div className="border-b-2 py-4 pr-6">

--- a/client/pages/post/index.tsx
+++ b/client/pages/post/index.tsx
@@ -1,22 +1,14 @@
 import { GetServerSideProps, NextPage } from 'next';
-import { useRouter } from 'next/router';
-import { useEffect } from 'react';
-import { toast } from 'react-toastify';
-import { useRecoilValue } from 'recoil';
-
-import { isLoginAtom } from '@atoms/loginAtom';
 
 import { Editor } from '@components/common/QuillEditor/Editor';
 import { Seo } from '@components/common/Seo';
+import { useEffect } from 'react';
+import { useCheckClickIsLogin } from '@libs/useCheckIsLogin';
 
 const Ask: NextPage = () => {
-  const isLogin = useRecoilValue(isLoginAtom);
-  const router = useRouter();
+  const checkIsLogin = useCheckClickIsLogin();
   useEffect(() => {
-    if (!isLogin) {
-      toast.error('로그인 해주세요.');
-      router.back();
-    }
+    checkIsLogin();
   }, []);
   return (
     <>

--- a/client/pages/signup-email/index.tsx
+++ b/client/pages/signup-email/index.tsx
@@ -40,7 +40,7 @@ const SignUpWithEmail: NextPage = () => {
   const onClickSignUp = async (e: React.MouseEvent<HTMLElement>) => {
     e.preventDefault();
     try {
-      signUpWithEmailAndKey(email, authKey, password, nickname);
+      signUpWithEmailAndKey({ email, authKey, password, nickname });
       toast.success('가입이 완료되었습니다! 로그인 페이지로 이동할게요.😉');
     } catch (error) {
       console.error('error', error);


### PR DESCRIPTION
- 각 링크에 대한 컴포넌트를 map 함수를 이용하여 처리했습니다.
- 중복되는 className을 따로 분리해서 처리했습니다.
- SearchWithTagButton 함수로 들어오는 인자에 대한 타입을 추가했습니다.
- Editor에 관한 코드도 제가 짠 코드 참고해서 리팩토링했습니다.
- useCheckIsLogin 훅에 대해 confirmAlert 적용을 하여 useCheckClickIsLogin 함수가 사용되는 곳에 confirmAlert가 나타나도록 하였습니다.
- currUserId에 타입 선언했습니다.
- useCheckIsLogin.ts 파일에 이미 isLogin을 판별하는 로직이 존재하고 있기 때문에 isLogin을 다시 확인할 필요는 없다고 생각해서 checkIsLogin 함수를 이용하여 리팩토링 했습니다. 다른 의견 있으시면 말씀 부탁드려요.
- signUpApi에 있던 함수 파라미터 전달에 오류가 나서 구조 분해 할당을 이용해서 값을 넣는 방식으로 수정했습니다.
- any로 설정되어 있던 부분은 타입 지정했습니다.
- 메인에서 '최근 질문' 클릭 시 질문 리스트 페이지로 넘어가게 설정했습니다.
- 프로필 수정 시 따로 피드백이 없어서 toast 메시지를 추가했습니다.