### PR TITLE
merge : 게시글 상세 페이지 중복 조회수 방지 로직 주석처리 및 article.get 패키지 내부 테스트 가독성 향상

### DIFF
--- a/server/morak_back_end/src/main/java/com/morakmorak/morak_back_end/controller/ArticleController.java
+++ b/server/morak_back_end/src/main/java/com/morakmorak/morak_back_end/controller/ArticleController.java
@@ -13,7 +13,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
 @RestController
@@ -68,8 +67,7 @@ public class ArticleController {
     @ResponseStatus(HttpStatus.OK)
     public ArticleDto.ResponseDetailArticle findDetailArticle(@RequestUser UserDto.UserInfo userInfo,
                                                               @PathVariable("article-id") Long articleId,
-                                                              HttpServletRequest request,
-                                                              HttpServletResponse response) {
+                                                              HttpServletRequest request) {
         String ip = articleMapper.getIp(request);
         return articleService.findDetailArticle(articleId, userInfo, ip);
     }

--- a/server/morak_back_end/src/test/java/com/morakmorak/morak_back_end/Integration/article/get/ArticleGetTest.java
+++ b/server/morak_back_end/src/test/java/com/morakmorak/morak_back_end/Integration/article/get/ArticleGetTest.java
@@ -1,27 +1,17 @@
 package com.morakmorak.morak_back_end.Integration.article.get;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.morakmorak.morak_back_end.dto.ArticleDto;
-import com.morakmorak.morak_back_end.dto.AvatarDto;
-import com.morakmorak.morak_back_end.dto.CommentDto;
-import com.morakmorak.morak_back_end.dto.UserDto;
 import com.morakmorak.morak_back_end.entity.*;
 import com.morakmorak.morak_back_end.entity.enums.*;
-import com.morakmorak.morak_back_end.mapper.ArticleMapper;
-import com.morakmorak.morak_back_end.repository.CategoryRepository;
-import com.morakmorak.morak_back_end.repository.FileRepository;
-import com.morakmorak.morak_back_end.repository.TagRepository;
 import com.morakmorak.morak_back_end.repository.article.ArticleRepository;
-import com.morakmorak.morak_back_end.repository.article.ArticleTagRepository;
-import com.morakmorak.morak_back_end.repository.redis.RedisRepositoryImpl;
 import com.morakmorak.morak_back_end.repository.user.UserRepository;
 import com.morakmorak.morak_back_end.security.util.JwtTokenUtil;
-import com.morakmorak.morak_back_end.service.ArticleService;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,6 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 })
 @AutoConfigureMockMvc
 @Transactional
+@Slf4j
 public class ArticleGetTest {
     @Autowired
     JwtTokenUtil jwtTokenUtil;
@@ -57,34 +48,11 @@ public class ArticleGetTest {
     MockMvc mockMvc;
 
     @Autowired
-    ObjectMapper objectMapper;
-
-    @Autowired
-    ArticleService articleService;
-
-    @Autowired
-    FileRepository fileRepository;
-
-    @Autowired
-    TagRepository tagRepository;
-
-    @Autowired
-    ArticleTagRepository articleTagRepository;
-
-    @Autowired
-    CategoryRepository categoryRepository;
-
-    @Autowired
-    ArticleMapper articleMapper;
-
-    @Autowired
     UserRepository userRepository;
 
     @Autowired
     ArticleRepository articleRepository;
 
-    @Autowired
-    RedisRepositoryImpl<ArticleDto.Ip> redisRepository;
 
     @Test
     @DisplayName("게시글을 타이틀명과 카테고리로 검색 성공시 201코드와 Ok를 반환한다.")
@@ -291,8 +259,6 @@ public class ArticleGetTest {
     @Test
     @DisplayName("게시글 상세조회 시 삭제처리된 게시글의 경우 403 Forbidden을 보낸다.")
     public void findDetailArticle_failed() throws Exception {
-        em.flush();
-        em.clear();
         //given
         Article dbArticle = Article.builder()
                 .articleStatus(ArticleStatus.REMOVED)
@@ -309,7 +275,7 @@ public class ArticleGetTest {
 
         //when
         ResultActions perform = mockMvc.perform(
-                get("/articles/{article-id}" , dbArticle.getId())
+                get("/articles/{article-id}", dbArticle.getId())
                         .header("User-Agent", "Mozilla 5.0")
                         .header(JWT_HEADER, accessToken)
         );
@@ -321,8 +287,6 @@ public class ArticleGetTest {
     @Test
     @DisplayName("게시글 상세조회 컨트롤러 이용시 jwt토큰을 보낼시 isBookmarked와 isLiked를 확인하고 true or false를 보낸다.")
     public void findDetailArticle_suc() throws Exception {
-        em.flush();
-        em.clear();
         //given
 
         Tag C = Tag.builder().name(TagName.C).build();
@@ -376,10 +340,9 @@ public class ArticleGetTest {
 
         //when
         ResultActions perform = mockMvc.perform(
-                get("/articles/" + article.getId())
+                RestDocumentationRequestBuilders.get("/articles/{article-id}", article.getId())
                         .header("User-Agent", "Mozilla 5.0")
                         .header(JWT_HEADER, accessToken)
-
         );
 
         //then
@@ -422,8 +385,6 @@ public class ArticleGetTest {
     @Test
     @DisplayName("게시글 상세조회 컨트롤러 해당 게시글이 5번의 신고를 당했을경우.")
     public void findDetailBlockArticle_suc() throws Exception {
-        em.flush();
-        em.clear();
         //given
 
         Tag C = Tag.builder().name(TagName.C).build();
@@ -478,17 +439,12 @@ public class ArticleGetTest {
         User dbUser = userRepository.findUserByEmail(user.getEmail()).orElseThrow(() -> new RuntimeException("유저없음"));
         String accessToken = jwtTokenUtil.createAccessToken(user.getEmail(), dbUser.getId(), ROLE_USER_LIST, NICKNAME1);
 
-        Article dbArticle = articleRepository.findArticleByContent("안녕하세요 콘탠트입니다. 제발 되었으면 좋겠습니다.")
-                .orElseThrow(() -> new RuntimeException("게시글 없음"));
-
-
         //when
         ResultActions perform = mockMvc.perform(
-                get("/articles/" + article.getId())
+                RestDocumentationRequestBuilders.get("/articles/{article-id}", article.getId())
                         .header("User-Agent", "Mozilla 5.0")
                         .header(JWT_HEADER, accessToken)
         );
-
         //then
         perform.andExpect(status().isOk())
                 .andExpect(jsonPath("$.articleId").value(article.getId()))
@@ -517,8 +473,6 @@ public class ArticleGetTest {
     @Test
     @DisplayName("게시글 상세조회시 jwt 토큰을 보내지 않을시 isBookmarked와 isLiked를 flase로 보낸다.")
     public void findDetailArticle_suc2() throws Exception {
-        em.flush();
-        em.clear();
         //given
         Tag JAVA = Tag.builder().name(TagName.JAVA).build();
         em.persist(JAVA);
@@ -567,23 +521,12 @@ public class ArticleGetTest {
         em.persist(comment);
         article.getComments().add(comment);
 
-
-        CommentDto.Response commentDto = CommentDto.Response.builder().avatar(AvatarDto.SimpleResponse.of(avatar))
-                .articleId(article.getId())
-                .commentId(comment.getId())
-                .content(comment.getContent())
-                .userInfo(UserDto.ResponseSimpleUserDto.of(user))
-                .avatar(AvatarDto.SimpleResponse.of(avatar))
-                .build();
         Long id = userRepository.findUserByEmail(EMAIL1).orElseThrow().getId();
-
-        String accessToken = jwtTokenUtil.createAccessToken(EMAIL1, id, ROLE_USER_LIST, NICKNAME1);
 
         //when
         ResultActions perform = mockMvc.perform(
-                get("/articles/" + article.getId())
+                RestDocumentationRequestBuilders.get("/articles/{article-id}", article.getId())
                         .header("User-Agent", "Mozilla 5.0")
-
         );
 
         //then

--- a/server/morak_back_end/src/test/java/com/morakmorak/morak_back_end/Integration/article/patch/ArticleUpdateTest.java
+++ b/server/morak_back_end/src/test/java/com/morakmorak/morak_back_end/Integration/article/patch/ArticleUpdateTest.java
@@ -63,12 +63,6 @@ public class ArticleUpdateTest {
     ObjectMapper objectMapper;
 
     @Autowired
-    RedisRepository<String> mailAuthRedisRepository;
-
-    @Autowired
-    ArticleService articleService;
-
-    @Autowired
     FileRepository fileRepository;
 
     @Autowired

--- a/server/morak_back_end/src/test/java/com/morakmorak/morak_back_end/Integration/article/post/ArticlePressLikeButton.java
+++ b/server/morak_back_end/src/test/java/com/morakmorak/morak_back_end/Integration/article/post/ArticlePressLikeButton.java
@@ -41,15 +41,6 @@ public class ArticlePressLikeButton {
     MockMvc mockMvc;
 
     @Autowired
-    ObjectMapper objectMapper;
-
-    @Autowired
-    RedisRepository<String> mailAuthRedisRepository;
-
-    @Autowired
-    ArticleService articleService;
-
-    @Autowired
     EntityManager em;
 
     @Autowired

--- a/server/morak_back_end/src/test/java/com/morakmorak/morak_back_end/Integration/article/post/ArticleUploadTest.java
+++ b/server/morak_back_end/src/test/java/com/morakmorak/morak_back_end/Integration/article/post/ArticleUploadTest.java
@@ -57,12 +57,6 @@ public class ArticleUploadTest {
     ObjectMapper objectMapper;
 
     @Autowired
-    RedisRepository<String> mailAuthRedisRepository;
-
-    @Autowired
-    ArticleService articleService;
-
-    @Autowired
     FileRepository fileRepository;
 
     @Autowired
@@ -74,8 +68,6 @@ public class ArticleUploadTest {
     @Autowired
     UserRepository userRepository;
 
-    @Autowired
-    ArticleRepository articleRepository;
 
     @BeforeEach
     public void originallySavedElements() throws Exception {

--- a/server/morak_back_end/src/test/java/com/morakmorak/morak_back_end/Integration/article/post/ReportArticleTest.java
+++ b/server/morak_back_end/src/test/java/com/morakmorak/morak_back_end/Integration/article/post/ReportArticleTest.java
@@ -8,10 +8,8 @@ import com.morakmorak.morak_back_end.entity.User;
 import com.morakmorak.morak_back_end.entity.enums.ReportReason;
 import com.morakmorak.morak_back_end.repository.*;
 import com.morakmorak.morak_back_end.repository.article.ArticleRepository;
-import com.morakmorak.morak_back_end.repository.redis.RedisRepository;
 import com.morakmorak.morak_back_end.repository.user.UserRepository;
 import com.morakmorak.morak_back_end.security.util.JwtTokenUtil;
-import com.morakmorak.morak_back_end.service.ArticleService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,21 +45,6 @@ public class ReportArticleTest {
 
     @Autowired
     ObjectMapper objectMapper;
-
-    @Autowired
-    RedisRepository<String> mailAuthRedisRepository;
-
-    @Autowired
-    ArticleService articleService;
-
-    @Autowired
-    FileRepository fileRepository;
-
-    @Autowired
-    TagRepository tagRepository;
-
-    @Autowired
-    CategoryRepository categoryRepository;
 
     @Autowired
     UserRepository userRepository;


### PR DESCRIPTION
중복 조회수 방지 로직이 클라이언트와 함께 통신시 계속 다른 ip값이 넘어와 로직이 원하는대로 작동하지 않음을 확인하여 주석처리 하였음. 

클라이언트 측과 상의하여 정확히 넘어오는 ip값이 무서인지 확인해보고 로직을 수정후 주석 제거할것 